### PR TITLE
Update streamer dependency

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -7,7 +7,7 @@
         "sampctl/samp-stdlib",
         "Southclaws/samp-logger",
         "pawn-lang/YSI-Includes@5.x",
-        "samp-incognito/samp-streamer-plugin:v2.9.3",
+        "samp-incognito/samp-streamer-plugin:v2.9.6",
         "ScavengeSurvive/mathutil"
     ],
     "dev_dependencies": [


### PR DESCRIPTION
Related to #7 
This also fixes tests for all packages relying on the personal-space include which weren't specifying a newer build of the streamer, like e.g. the inventory-dialog library.